### PR TITLE
Allow overriding default tags on notifications

### DIFF
--- a/lib/capistrano/tasks/flowdock.cap
+++ b/lib/capistrano/tasks/flowdock.cap
@@ -53,7 +53,7 @@ namespace :flowdock do
         flow.push_to_team_inbox(:format => "html",
           :subject => "#{fetch(:flowdock_project_name)} deployed with branch #{fetch(:branch)} on ##{fetch(:flowdock_deploy_env)}",
           :content => notification_message,
-          :tags => ["deploy", "#{fetch(:flowdock_deploy_env)}"] || fetch(:flowdock_deploy_tags))
+          :tags => fetch(:flowdock_deploy_tags, ["deploy", "#{fetch(:flowdock_deploy_env)}"]))
       end unless fetch('dry_run')
     rescue => e
       puts "Flowdock: error in sending notification to your flow: #{e.to_s}"


### PR DESCRIPTION
Instead of appending ot default tags, it'd be cool to be able to override our defaults when they don't make sense.