### PR TITLE
Filter out no_release roles, as they don't run the deploy flow tasks, an...

### DIFF
--- a/lib/capistrano/tasks/flowdock.cap
+++ b/lib/capistrano/tasks/flowdock.cap
@@ -1,6 +1,6 @@
 namespace :flowdock do
   task :read_current_deployed_branch do
-    on roles(:all) do
+    on release_roles(:all) do
       begin
         current_branch = capture(:cat, "#{current_path}/BRANCH").chomp
       rescue
@@ -12,7 +12,7 @@ namespace :flowdock do
   end
 
   task :save_deployed_branch do
-    on roles(:all) do
+    on release_roles(:all) do
       begin
         execute("echo '#{fetch(:flowdock_deploy_head_name)}' > #{current_path}/BRANCH")
       rescue => e


### PR DESCRIPTION
...d thus are missing BRANCH, revisions.log, etc.

Basically, the issue here is that Capistrano allows you to define custom roles that don't participate in the release process, e.g. a :redis role or similar. You do this by defining your custom role with the :no_release attribute, e.g.

```
role :redis, :no_release => true
```

This fix uses the built in 'release_roles' DSL method which filters out hosts with the :no_release option set.

The impact here is that currently, the change tracking functionality is broken in that flowdock tries to write to a directory that doesn't exist, which causes the task to fail.

Thanks,

Andy
